### PR TITLE
feat: mini-view, hide cardinal letters, auto hide labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Select "Manage Resources"
 | windrose_draw_north_offset | number  |              0               |    -     | At what degrees the north direction is drawn. For example, if you want the windrose north orientation the same as your properties north orientation                   |
 | matching_strategy          | string  |       direction-first        |    -     | How to match direction and speed measurements. Find a speed with each direction or a direction with each speed measurement. Options: `direction-first`, `speed-first` |
 | colors                     | object  |                              |    -     | Configure colors for different parts of the windrose and windspeedbar. See object Colors.                                                                             |
+| show_wind_text       | boolean |             true             |    -     | Show the cardinal direction letters in the windrose. For example, set to false when space is limited to omit the direction letters. |
 | log_level                  | string  |             WARN             |    -     | Browser console log level, options: NONE, ERROR, WARN, INFO, DEBUG and TRACE                                                                                          |
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-windrose-card-project",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-windrose-card-project",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.1",

--- a/src/card/CardConfig.ts
+++ b/src/card/CardConfig.ts
@@ -31,6 +31,7 @@ export interface CardConfig {
     wind_direction_count: number;
     matching_strategy: string;
     direction_speed_time_diff: number;
+    show_wind_text: boolean;
     log_level: string;
 
     colors: CardConfigColors;

--- a/src/config/CardConfigWrapper.ts
+++ b/src/config/CardConfigWrapper.ts
@@ -31,6 +31,7 @@ export class CardConfigWrapper {
     speedRanges: SpeedRange[] = [];
     matchingStrategy: string;
     cardColor: CardColors;
+    showWindText: boolean;
     logLevel: string;
 
     filterEntitiesQueryParameter: string;
@@ -68,6 +69,7 @@ export class CardConfigWrapper {
             cardinal_direction_letters: GlobalConfig.defaultCardinalDirectionLetters,
             matching_strategy: GlobalConfig.defaultMatchingStategy,
             center_calm_percentage: GlobalConfig.defaultCenterCalmPercentage,
+            showWindText: true,
             log_level: GlobalConfig.defaultLogLevel
         };
     }
@@ -96,6 +98,7 @@ export class CardConfigWrapper {
         this.matchingStrategy = this.checkMatchingStrategy();
         this.filterEntitiesQueryParameter = this.createEntitiesQueryParameter();
         this.cardColor = this.checkCardColors();
+        this.showWindText = this.checkBooleanDefaultTrue(cardConfig.show_wind_text);
         this.logLevel = Log.checkLogLevel(this.cardConfig.log_level);
         Log.info('Config check OK');
     }

--- a/src/config/WindRoseConfig.ts
+++ b/src/config/WindRoseConfig.ts
@@ -9,6 +9,7 @@ export class WindRoseConfig {
         public cardinalDirectionLetters: string,
         public directionCompensation: number,
         public windRoseDrawNorthOffset: number,
+        public showWindText: boolean,
 
         public roseLinesColor: string,
         public roseDirectionLettersColor: string,

--- a/src/config/WindRoseConfigFactory.ts
+++ b/src/config/WindRoseConfigFactory.ts
@@ -17,6 +17,7 @@ export class WindRoseConfigFactory {
             this.cardConfig.cardinalDirectionLetters,
             this.cardConfig.windDirectionEntity.directionCompensation,
             this.cardConfig.windRoseDrawNorthOffset,
+            this.cardConfig.showWindText,
             this.cardConfig.cardColor.roseLines,
             this.cardConfig.cardColor.roseDirectionLetters,
             this.cardConfig.cardColor.rosePercentages);

--- a/src/dimensions/DimensionsCalculator.ts
+++ b/src/dimensions/DimensionsCalculator.ts
@@ -8,7 +8,8 @@ export class DimensionsCalculator {
     public calculateWindRoseDimensions(canvasWidth: number,
                                 maxWidth: number | undefined,
                                 windBarCount: number,
-                                windspeedBarLocation: string): WindRoseDimensions {
+                                windspeedBarLocation: string,
+                                showWindText: boolean): WindRoseDimensions {
 
         let offsetWidth = 0;
         let roseWidth = canvasWidth;
@@ -20,7 +21,7 @@ export class DimensionsCalculator {
             roseWidth = roseWidth - ((60 + 12) * windBarCount);
             offsetWidth = (canvasWidth - roseWidth - ((60 + 12) * windBarCount)) / 2;
         }
-        let outerRadius = (roseWidth / 2) - 35;
+        let outerRadius = (roseWidth / 2) - (showWindText ? 35 : 5);
         let roseCenterX = offsetWidth + (roseWidth / 2);
         let roseCenterY = outerRadius + 25
         let canvasHeight = 0;
@@ -35,18 +36,18 @@ export class DimensionsCalculator {
         return new WindRoseDimensions(roseCenterX, roseCenterY, offsetWidth, outerRadius, canvasHeight);
     }
 
-    public calculatorWindBarDimensions(dimensions: WindRoseDimensions, barLocation: string, index: number) {
+    public calculatorWindBarDimensions(dimensions: WindRoseDimensions, barLocation: string, index: number, showWindText: boolean) {
         if (barLocation === 'bottom') {
             return new WindBarDimensions(
                 dimensions.offsetWidth + 5,
-                dimensions.centerY + dimensions.outerRadius + 30 + ((GlobalConfig.horizontalBarHeight + 40) * index),
+                dimensions.centerY + dimensions.outerRadius + (showWindText ? 30 : 5) + ((GlobalConfig.horizontalBarHeight + 40) * index),
                 GlobalConfig.horizontalBarHeight,
-                ((dimensions.outerRadius + 30) * 2)
+                ((dimensions.outerRadius + (showWindText ? 30: 0)) * 2)
             )
         }
         if (barLocation === 'right') {
             return new WindBarDimensions(
-                dimensions.centerX + dimensions.outerRadius + 35 + ((GlobalConfig.verticalBarHeight + 60) * index),
+                dimensions.centerX + dimensions.outerRadius + (showWindText ? 35 : 5) + ((GlobalConfig.verticalBarHeight + 60) * index),
                 dimensions.centerY + dimensions.outerRadius + 20,
                 GlobalConfig.verticalBarHeight,
                 dimensions.outerRadius * 2 + 24

--- a/src/renderer/WindBarRenderer.ts
+++ b/src/renderer/WindBarRenderer.ts
@@ -135,7 +135,11 @@ export class WindBarRenderer {
         const lengthMaxRange = (this.dimensions.length / highestRangeMeasured)
         const maxScale = this.speedRanges[highestRangeMeasured - 1].minSpeed;
 
-        canvasContext.font = '13px Arial';
+        if (lengthMaxRange < 30) {
+            canvasContext.font = (lengthMaxRange / 2).toString() + 'px Arial';
+        } else {
+            canvasContext.font = '13px Arial';
+        }
         canvasContext.textAlign = 'left';
         canvasContext.textBaseline = 'bottom';
         canvasContext.lineWidth = 1;

--- a/src/renderer/WindRoseDirigent.ts
+++ b/src/renderer/WindRoseDirigent.ts
@@ -78,12 +78,13 @@ export class WindRoseDirigent {
                 width,
                 this.cardConfig.maxWidth,
                 this.cardConfig.windBarCount(),
-                this.cardConfig.windspeedBarLocation);
+                this.cardConfig.windspeedBarLocation,
+                this.cardConfig.showWindText);
             this.windRoseRenderer.updateDimensions(roseDimensions);
 
             for (let i = 0; i < this.cardConfig.windBarCount(); i++) {
                 this.windBarRenderers[i].updateDimensions(this.dimensionCalculator.calculatorWindBarDimensions(
-                    roseDimensions, this.cardConfig.windspeedBarLocation, i));
+                    roseDimensions, this.cardConfig.windspeedBarLocation, i, this.cardConfig.showWindText));
             }
             this.dimensionsReady = true;
             return roseDimensions.canvasHeight;

--- a/src/renderer/WindRoseRendererCenterCalm.ts
+++ b/src/renderer/WindRoseRendererCenterCalm.ts
@@ -115,30 +115,37 @@ export class WindRoseRendererCenterCalm {
         }
 
         // Wind direction text
-        const textCirlceSpace = 15;
-        canvasContext.fillStyle = this.config.roseDirectionLettersColor;
-        canvasContext.font = '22px Arial';
-        canvasContext.textAlign = 'center';
-        canvasContext.textBaseline = 'middle';
-        this.drawText(canvasContext, this.config.cardinalDirectionLetters[0], 0, 0 - this.dimensions.outerRadius - textCirlceSpace + 2);
-        this.drawText(canvasContext, this.config.cardinalDirectionLetters[2], 0, this.dimensions.outerRadius + textCirlceSpace);
-        this.drawText(canvasContext, this.config.cardinalDirectionLetters[1], this.dimensions.outerRadius + textCirlceSpace, 0);
-        this.drawText(canvasContext, this.config.cardinalDirectionLetters[3], 0 - this.dimensions.outerRadius - textCirlceSpace, 0);
+        if (this.config.showWindText) {
+            const textCirlceSpace = 15;
+            canvasContext.fillStyle = this.config.roseDirectionLettersColor;
+            canvasContext.font = '22px Arial';
+            canvasContext.textAlign = 'center';
+            canvasContext.textBaseline = 'middle';
+            this.drawText(canvasContext, this.config.cardinalDirectionLetters[0], 0, 0 - this.dimensions.outerRadius - textCirlceSpace + 2);
+            this.drawText(canvasContext, this.config.cardinalDirectionLetters[2], 0, this.dimensions.outerRadius + textCirlceSpace);
+            this.drawText(canvasContext, this.config.cardinalDirectionLetters[1], this.dimensions.outerRadius + textCirlceSpace, 0);
+            this.drawText(canvasContext, this.config.cardinalDirectionLetters[3], 0 - this.dimensions.outerRadius - textCirlceSpace, 0);
+        }
     }
 
     private drawCircleLegend(canvasContext: CanvasRenderingContext2D) {
         canvasContext.font = "10px Arial";
         canvasContext.fillStyle = this.config.rosePercentagesColor
         canvasContext.textAlign = 'center';
-        canvasContext.textBaseline = 'bottom';
+        canvasContext.textBaseline = 'middle';
         const radiusStep = (this.dimensions.outerRadius - this.config.centerRadius) / this.windRoseData.circleCount;
         const centerXY = Math.cos(DrawUtil.toRadians(45)) * this.config.centerRadius;
         const xy = Math.cos(DrawUtil.toRadians(45)) * radiusStep;
+        let lastYPos = centerXY + (xy * this.windRoseData.circleCount) + 12;
 
-        for (let i = 1; i <= this.windRoseData.circleCount; i++) {
+        for (let i = this.windRoseData.circleCount; i >= 1; i--) {
             const xPos = centerXY + (xy * i);
             const yPos = centerXY + (xy * i);
-            this.drawText(canvasContext, (this.windRoseData.percentagePerCircle * i) + "%", xPos, yPos);
+            const yDiff = lastYPos - yPos;
+            if (yDiff > 10) {
+                lastYPos = yPos;
+                this.drawText(canvasContext, (this.windRoseData.percentagePerCircle * i) + "%", xPos, yPos);
+            }
         }
     }
 

--- a/src/renderer/WindRoseRendererStandaard.ts
+++ b/src/renderer/WindRoseRendererStandaard.ts
@@ -112,30 +112,37 @@ export class WindRoseRendererStandaard {
         }
 
         // Wind direction text
-        const textCirlceSpace = 15;
-        canvasContext.fillStyle = this.config.roseDirectionLettersColor;
-        canvasContext.font = '22px Arial';
-        canvasContext.textAlign = 'center';
-        canvasContext.textBaseline = 'middle';
-        this.drawText(canvasContext, this.config.cardinalDirectionLetters[0], 0, 0 - this.dimensions.outerRadius - textCirlceSpace + 2);
-        this.drawText(canvasContext, this.config.cardinalDirectionLetters[2], 0, this.dimensions.outerRadius + textCirlceSpace);
-        this.drawText(canvasContext, this.config.cardinalDirectionLetters[1], this.dimensions.outerRadius + textCirlceSpace, 0);
-        this.drawText(canvasContext, this.config.cardinalDirectionLetters[3], 0 - this.dimensions.outerRadius - textCirlceSpace, 0);
+        if (this.config.showWindText) {
+            const textCirlceSpace = 15;
+            canvasContext.fillStyle = this.config.roseDirectionLettersColor;
+            canvasContext.font = '22px Arial';
+            canvasContext.textAlign = 'center';
+            canvasContext.textBaseline = 'middle';
+            this.drawText(canvasContext, this.config.cardinalDirectionLetters[0], 0, 0 - this.dimensions.outerRadius - textCirlceSpace + 2);
+            this.drawText(canvasContext, this.config.cardinalDirectionLetters[2], 0, this.dimensions.outerRadius + textCirlceSpace);
+            this.drawText(canvasContext, this.config.cardinalDirectionLetters[1], this.dimensions.outerRadius + textCirlceSpace, 0);
+            this.drawText(canvasContext, this.config.cardinalDirectionLetters[3], 0 - this.dimensions.outerRadius - textCirlceSpace, 0);
+        }
     }
 
     private drawCircleLegend(canvasContext: CanvasRenderingContext2D) {
         canvasContext.font = "10px Arial";
         canvasContext.fillStyle = this.config.rosePercentagesColor
         canvasContext.textAlign = 'center';
-        canvasContext.textBaseline = 'bottom';
+        canvasContext.textBaseline = 'middle';
         const radiusStep = this.dimensions.outerRadius / this.windRoseData.circleCount;
         const centerXY = 0;
         const xy = Math.cos(DrawUtil.toRadians(45)) * radiusStep;
+        let lastYPos = centerXY + (xy * this.windRoseData.circleCount) + 12;
 
-        for (let i = 1; i <= this.windRoseData.circleCount; i++) {
+        for (let i = this.windRoseData.circleCount; i >= 1; i--) {
             const xPos = centerXY + (xy * i);
             const yPos = centerXY + (xy * i);
-            this.drawText(canvasContext, (this.windRoseData.percentagePerCircle * i) + "%", xPos, yPos);
+            const yDiff = lastYPos - yPos;
+            if (yDiff > 10) {
+                lastYPos = yPos;
+                this.drawText(canvasContext, (this.windRoseData.percentagePerCircle * i) + "%", xPos, yPos);
+            }
         }
     }
 


### PR DESCRIPTION
Small adjustments to fit in a small space, like a horizontal gallery. New option `show_wind_text`, which shows the cardinal letters by default, set to `false` for small spaces. The labels on the windrose are hidden automatically if they overlap with the previous one. E.g. the most outer label is always shown. Reduce font size text in horizontal bar, if section width is under 30.