### PR TITLE
feat: Add historical time windows, statistical templates, and text al…

### DIFF
--- a/src/card/CardConfigDataPeriod.ts
+++ b/src/card/CardConfigDataPeriod.ts
@@ -4,6 +4,8 @@ export interface CardConfigDataPeriod {
     hours_to_show: number;
     period_selector: CardConfigPeriodSelector;
     from_hour_of_day: number;
+    from_hours_ago: number;
+    to_hours_ago: number;
     time_interval: number;
     log_measurement_counts: boolean;
 }

--- a/src/card/CardConfigTextBlock.ts
+++ b/src/card/CardConfigTextBlock.ts
@@ -2,4 +2,5 @@ export interface CardConfigTextBlock {
     text: string;
     text_size: number;
     text_color: string;
+    text_align: string;
 }

--- a/src/card/WindRoseCard.ts
+++ b/src/card/WindRoseCard.ts
@@ -163,7 +163,7 @@ export class WindRoseCard extends LitElement {
         if (textBlock === undefined || textBlock.text === '') {
             return html``;
         }
-        return html`<div id="text-block-${location}" class="text-block" style="color: ${textBlock.textColor}; font-size: ${textBlock.textSize}px"></div>`;
+        return html`<div id="text-block-${location}" class="text-block" style="color: ${textBlock.textColor}; font-size: ${textBlock.textSize}px; text-align: ${textBlock.textAlign}"></div>`;
     }
 
     firstUpdated(): void {

--- a/src/config/DataPeriod.ts
+++ b/src/config/DataPeriod.ts
@@ -8,6 +8,8 @@ export class DataPeriod {
         public hourstoShow: number | undefined,
         public periodSelector: PeriodSelector | undefined,
         public readonly fromHourOfDay: number | undefined,
+        public readonly fromHoursAgo: number | undefined,
+        public readonly toHoursAgo: number | undefined,
         public readonly timeInterval: number,
         public readonly logMeasurementCounts: boolean) {
     }
@@ -16,6 +18,7 @@ export class DataPeriod {
         const oldHoursToShowCheck = this.checkHoursToShow(oldHoursToShow);
         const hoursToShowCheck = this.checkHoursToShow(dataPeriod?.hours_to_show);
         const fromHourOfDayCheck = this.checkFromHourOfDay(dataPeriod?.from_hour_of_day);
+        const timeWindowCheck = this.checkTimeWindow(dataPeriod?.from_hours_ago, dataPeriod?.to_hours_ago);
         const logMeasurementCounts = ConfigCheckUtils.checkBooleanDefaultFalse(dataPeriod?.log_measurement_counts);
         let timeInterval = ConfigCheckUtils.checkNummerOrDefault(dataPeriod?.time_interval, 60);
         if (timeInterval === 0) {
@@ -24,7 +27,7 @@ export class DataPeriod {
         const periodSelector = PeriodSelector.fromConfig(dataPeriod?.period_selector);
         if (oldHoursToShowCheck) {
             Log.warn('WindRoseCard: hours_to_show config is deprecated, use the data_period object.');
-            return new DataPeriod(oldHoursToShow, undefined, undefined, timeInterval, logMeasurementCounts);
+            return new DataPeriod(oldHoursToShow, undefined, undefined, undefined, undefined, timeInterval, logMeasurementCounts);
         }
         let optionCount = 0;
         if (periodSelector) {
@@ -36,17 +39,20 @@ export class DataPeriod {
         if (fromHourOfDayCheck) {
             optionCount++;
         }
+        if (timeWindowCheck) {
+            optionCount++;
+        }
         if (optionCount > 1) {
-            throw new Error('WindRoseCard: Only one is allowed: hours_to_show, from_hour_of_day or period_selector');
+            throw new Error('WindRoseCard: Only one is allowed: hours_to_show, from_hour_of_day, time window (from_hours_ago/to_hours_ago) or period_selector');
         } else if (optionCount === 0) {
-            throw new Error('WindRoseCard: hours_to_show, from_hour_of_day or period_selector of object data_period should be filled.');
+            throw new Error('WindRoseCard: hours_to_show, from_hour_of_day, time window (from_hours_ago/to_hours_ago) or period_selector of object data_period should be filled.');
         }
         let hoursToShow = dataPeriod?.hours_to_show;
         if (periodSelector && periodSelector.buttons) {
             const activePeriod = periodSelector.buttons.find((button) => button.active);
             hoursToShow = activePeriod!.hours;
         }
-        return new DataPeriod(hoursToShow, periodSelector, dataPeriod?.from_hour_of_day, timeInterval, logMeasurementCounts);
+        return new DataPeriod(hoursToShow, periodSelector, dataPeriod?.from_hour_of_day, dataPeriod?.from_hours_ago, dataPeriod?.to_hours_ago, timeInterval, logMeasurementCounts);
     }
 
     private static checkHoursToShow(hoursToShow: number | undefined): boolean {
@@ -63,6 +69,31 @@ export class DataPeriod {
             throw new Error('WindRoseCard: Invalid hours_to_show, should be a number between 0 and 23, hour of the day..');
         } else if (fromHourOfDay != null && fromHourOfDay >= 0) {
             return true
+        }
+        return false;
+    }
+
+    private static checkTimeWindow(fromHoursAgo: number | undefined, toHoursAgo: number | undefined): boolean {
+        const hasFromHoursAgo = fromHoursAgo != null && fromHoursAgo >= 0;
+        const hasToHoursAgo = toHoursAgo != null && toHoursAgo >= 0;
+        
+        if (hasFromHoursAgo && !hasToHoursAgo) {
+            throw new Error('WindRoseCard: from_hours_ago requires to_hours_ago to be set.');
+        }
+        if (!hasFromHoursAgo && hasToHoursAgo) {
+            throw new Error('WindRoseCard: to_hours_ago requires from_hours_ago to be set.');
+        }
+        if (hasFromHoursAgo && hasToHoursAgo) {
+            if (isNaN(fromHoursAgo!) || fromHoursAgo! < 0) {
+                throw new Error('WindRoseCard: Invalid from_hours_ago, should be a number >= 0.');
+            }
+            if (isNaN(toHoursAgo!) || toHoursAgo! < 0) {
+                throw new Error('WindRoseCard: Invalid to_hours_ago, should be a number >= 0.');
+            }
+            if (fromHoursAgo! < toHoursAgo!) {
+                throw new Error('WindRoseCard: from_hours_ago must be >= to_hours_ago.');
+            }
+            return true;
         }
         return false;
     }

--- a/src/config/TextBlock.ts
+++ b/src/config/TextBlock.ts
@@ -5,12 +5,14 @@ export class TextBlock {
     constructor(
         public readonly text: string,
         public readonly textSize: number,
-        public readonly textColor: string) {}
+        public readonly textColor: string,
+        public readonly textAlign: string) {}
 
     static fromConfig(config: CardConfigTextBlock): TextBlock | undefined {
         if (config == undefined) {
             return undefined;
         }
-        return new TextBlock(config.text, config.text_size, config.text_color);
+        const textAlign = config.text_align || 'left';
+        return new TextBlock(config.text, config.text_size, config.text_color, textAlign);
     }
 }

--- a/src/measurement-provider/HAWebservice.ts
+++ b/src/measurement-provider/HAWebservice.ts
@@ -6,11 +6,11 @@ export class HAWebservice {
     constructor(private readonly hass: HomeAssistant) {
     }
 
-    public getMeasurementData(startTime: Date, requestData: HARequestData): Promise<any> {
+    public getMeasurementData(startTime: Date, endTime: Date, requestData: HARequestData): Promise<any> {
         if (requestData.useStatistics) {
-            return this.getStatistics(startTime, [requestData.entity], requestData.statisticsPeriod!);
+            return this.getStatistics(startTime, endTime, [requestData.entity], requestData.statisticsPeriod!);
         }
-        return this.getHistory(startTime, new Date(), [requestData.entity], requestData.attribute !== undefined);
+        return this.getHistory(startTime, endTime, [requestData.entity], requestData.attribute !== undefined);
     }
 
     private getHistory(startTime: Date, endTime: Date, entities: string[], attributes: boolean): Promise<any> {
@@ -28,13 +28,14 @@ export class HAWebservice {
         return this.hass.callWS(historyMessage);
     }
 
-    private getStatistics(startTime: Date, entities: string[], period: string): Promise<any> {
+    private getStatistics(startTime: Date, endTime: Date, entities: string[], period: string): Promise<any> {
         if (entities.length === 0) {
             return Promise.resolve({});
         }
         const statisticsMessage = {
             "type": "recorder/statistics_during_period",
             "start_time": startTime,
+            "end_time": endTime,
             "period": period,
             "statistic_ids": entities,
             "types":["mean"]

--- a/src/render-bar/WindBarRenderer.ts
+++ b/src/render-bar/WindBarRenderer.ts
@@ -151,7 +151,7 @@ export class WindBarRenderer {
                 if (index === 0) {
                     align = 'start';
                 }
-                const label = this.svgUtil.drawText2(segmentPosition.start, speedLabelY, segmentPosition.minSpeed + '', TextAttributes.windBarAttribute(this.cardColors.barUnitValues, this.barSpeedTextSize, "hanging", align));
+                const label = this.svgUtil.drawText2(segmentPosition.start, speedLabelY, Math.round(segmentPosition.minSpeed) + '', TextAttributes.windBarAttribute(this.cardColors.barUnitValues, this.barSpeedTextSize, "hanging", align));
                 this.windBarGroup.add(label);
             }
 
@@ -165,7 +165,7 @@ export class WindBarRenderer {
         //Last label if needed
         const lastSegment = segmentPositions[segmentPositions.length - 1];
         if (!this.windSpeedEntityConfig.speedRangeBeaufort && lastSegment.showLastLabel) {
-            const label = this.svgUtil.drawText2(lastSegment.end, speedLabelY, lastSegment.maxSpeed + '', TextAttributes.windBarAttribute(this.cardColors.barUnitValues, this.barSpeedTextSize, "hanging", "end"));
+            const label = this.svgUtil.drawText2(lastSegment.end, speedLabelY, Math.round(lastSegment.maxSpeed) + '', TextAttributes.windBarAttribute(this.cardColors.barUnitValues, this.barSpeedTextSize, "hanging", "end"));
             this.windBarGroup.add(label);
         }
         //Unit label
@@ -205,7 +205,7 @@ export class WindBarRenderer {
                 if (index === 0) {
                     baseline = 'start';
                 }
-                const label = this.svgUtil.drawText2(speedLabelX, segmentPosition.start, segmentPosition.minSpeed + '', TextAttributes.windBarAttribute(this.cardColors.barUnitValues, this.barSpeedTextSize, baseline, "left"));
+                const label = this.svgUtil.drawText2(speedLabelX, segmentPosition.start, Math.round(segmentPosition.minSpeed) + '', TextAttributes.windBarAttribute(this.cardColors.barUnitValues, this.barSpeedTextSize, baseline, "left"));
                 this.windBarGroup.add(label);
             }
 
@@ -222,7 +222,7 @@ export class WindBarRenderer {
         const lastSegment = segmentPositions[segmentPositions.length - 1];
         //Last label if needed
         if (!this.windSpeedEntityConfig.speedRangeBeaufort && lastSegment.showLastLabel) {
-            const label = this.svgUtil.drawText2(speedLabelX, lastSegment.end, lastSegment.maxSpeed + '', TextAttributes.windBarAttribute(this.cardColors.barUnitValues, this.barSpeedTextSize, "hanging", "left"))
+            const label = this.svgUtil.drawText2(speedLabelX, lastSegment.end, Math.round(lastSegment.maxSpeed) + '', TextAttributes.windBarAttribute(this.cardColors.barUnitValues, this.barSpeedTextSize, "hanging", "left"))
             this.windBarGroup.add(label);
         }
 


### PR DESCRIPTION
# Historical Time Window Feature Implementation

## Overview
Added support for non-overlapping historical time windows to the windrose card, allowing users to view wind patterns from specific time periods in the past.  (Credit Claude AI for assistance)

## New Configuration Options

```yaml
data_period:
  from_hours_ago: 3  # Start: 3 hours before now
  to_hours_ago: 2    # End: 2 hours before now
```

This queries wind data from "3 hours ago" to "2 hours ago", excluding current data.

## Use Cases

### Hour-by-Hour Analysis Dashboard
Create multiple cards showing how wind patterns evolved:

```yaml
# Card 1: Last hour
data_period:
  from_hours_ago: 1
  to_hours_ago: 0

# Card 2: 1-2 hours ago  
data_period:
  from_hours_ago: 2
  to_hours_ago: 1

# Card 3: 2-3 hours ago
data_period:
  from_hours_ago: 3
  to_hours_ago: 2
```

### Comparison Analysis
Compare different time periods:

```yaml
# Morning wind (6-12 hours ago)
data_period:
  from_hours_ago: 12
  to_hours_ago: 6
text_blocks:
  top:
    text: "${iqr-range} mph"
    text_align: center

# Afternoon wind (0-6 hours ago)
data_period:
  from_hours_ago: 6
  to_hours_ago: 0
text_blocks:
  top:
    text: "${wind-description} mph"
    text_align: center
```

### 8-Hour Grid Dashboard
Complete weather-style wind history:

```yaml
type: vertical-stack
title: "Wind History - Last 8 Hours"
cards:
  - type: grid
    columns: 4
    cards:
      - type: custom:windrose-card
        data_period:
          from_hours_ago: 1
          to_hours_ago: 0
        text_blocks:
          top:
            text: "${iqr-range} mph"
            text_align: center
          bottom:
            text: "Gusts ${p90-speed}-${max-speed}"
            text_align: center
      # ... repeat for 8 cards with different time windows
```

## Statistical Template Functions

Added weather-style statistical templates for more realistic wind reporting:

### Available Templates
- `${iqr-range}` - Interquartile range (25th-75th percentile) - e.g. "4-8"
- `${median-speed}` - Median wind speed (excludes outliers)
- `${q1-speed}` - 25th percentile wind speed
- `${q3-speed}` - 75th percentile wind speed
- `${p90-speed}` - 90th percentile (gust threshold)
- `${wind-description}` - Complete weather description - e.g. "4-8 gusts to 12"
- `${average-speed}` - Traditional average (existing)
- `${max-speed}` - Maximum wind speed (existing)
- `${min-speed}` - Minimum wind speed (existing)

### Weather-Style Text Blocks
```yaml
text_blocks:
  top:
    text: "${iqr-range} mph"
    text_size: 10
    text_color: white
    text_align: center
  bottom:
    text: "Gusts ${p90-speed}-${max-speed}"
    text_size: 10
    text_align: center
```

**Result:** Shows "4-8 mph / Gusts 10-12" instead of misleading "0-12.3 mph average 6"

**Why This Works Better:**
- **Sustained Winds:** IQR shows typical wind speed (excludes calms and gusts)
- **Gust Range:** P90-Max shows the gust band (excludes outlier spikes)
- **Professional Format:** Matches weather service reporting style

### Why Statistical Templates Matter
- **Interquartile Range:** Excludes calm periods and extreme gusts, showing typical sustained winds
- **Median:** More representative than average when data has outliers
- **Percentiles:** Better understanding of wind distribution patterns
- **Weather Reporting:** Matches how meteorologists describe wind conditions

## Implementation Details

### Files Modified

1. **CardConfigDataPeriod.ts** - Added interface properties
2. **DataPeriod.ts** - Added validation and processing logic
3. **HAMeasurementProvider.ts** - Updated time calculation logic
4. **HAWebservice.ts** - Added endTime parameter support
5. **TemplateParser.ts** - Added statistical wind measures
6. **CardConfigTextBlock.ts** - Added text alignment support
7. **TextBlock.ts** - Added text alignment processing
8. **WindRoseCard.ts** - Added text alignment rendering

### Key Features

- **Backward Compatibility**: All existing configurations continue to work
- **Validation**: Comprehensive error checking for invalid configurations
- **Time Calculation**: Proper handling of both start and end times
- **API Integration**: Updated Home Assistant API calls to support time ranges

### Validation Rules

- `from_hours_ago` must be >= `to_hours_ago`
- Both values must be >= 0
- Both must be set together (can't use just one)
- Cannot combine with other time period options
- Maintains mutual exclusivity with existing options

### Time Calculation Logic

```javascript
// Time window mode
startTime = now - from_hours_ago
endTime = now - to_hours_ago

// Traditional mode (unchanged)
startTime = now - hours_to_show
endTime = now
```

