### PR TITLE
fix: defaultLogLevel type annotation produces undefined at runtime, causing WARN log level by default

### DIFF
--- a/src/config/GlobalConfig.test.ts
+++ b/src/config/GlobalConfig.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, test} from "@jest/globals";
+import {GlobalConfig} from "./GlobalConfig";
+import {Log} from "../util/Log";
+
+describe('GlobalConfig', () => {
+
+    describe('defaultLogLevel', () => {
+
+        test('is a string value, not undefined', () => {
+            expect(GlobalConfig.defaultLogLevel).toBeDefined();
+        });
+
+        test('is NONE', () => {
+            expect(GlobalConfig.defaultLogLevel).toBe('NONE');
+        });
+
+        test('is accepted by Log.checkLogLevel without throwing', () => {
+            expect(() => Log.checkLogLevel(GlobalConfig.defaultLogLevel)).not.toThrow();
+        });
+
+        test('Log.checkLogLevel does not fall back to WARN for the default level', () => {
+            // Previously defaultLogLevel was declared as a type annotation (`: 'NONE'`)
+            // instead of a value assignment (`= 'NONE'`), making it undefined at runtime.
+            // checkLogLevel(undefined) returns 'WARN', causing all warn-level messages to
+            // be logged by default when they should be suppressed.
+            expect(Log.checkLogLevel(GlobalConfig.defaultLogLevel)).toBe('NONE');
+        });
+
+    });
+
+});

--- a/src/config/GlobalConfig.ts
+++ b/src/config/GlobalConfig.ts
@@ -10,7 +10,7 @@ export class GlobalConfig {
     static defaultWindspeedBarFull = true;
     static defaultMatchingStategy = 'direction-first';
     static defaultCenterCalmPercentage = true;
-    static defaultLogLevel: 'NONE';
+    static defaultLogLevel = 'NONE';
     static defaultSpeedRangeBeaufort = true;
     static defaultCenterCalmPercenteCircleSize = 60
     static defaultCurrentDirectionArrowSize = 50;


### PR DESCRIPTION
## Summary

`GlobalConfig.defaultLogLevel` was declared with a TypeScript type annotation instead of a value assignment:

```typescript
// before (type annotation — value is undefined at runtime)
static defaultLogLevel: 'NONE';

// after (value assignment)
static defaultLogLevel = 'NONE';
```

At runtime `GlobalConfig.defaultLogLevel` was `undefined`. `Log.checkLogLevel` has an explicit `undefined` guard that returns `'WARN'` as a fallback:

```typescript
static checkLogLevel(logLevel: string | undefined): string {
    if (logLevel === undefined) {
        return 'WARN';  // ← hit every time, for every card instance
    }
    ...
}
```

This meant every card instance silently defaulted to WARN log level, flooding the browser console with warnings about non-numeric history values (e.g. `"unavailable"` states) that are expected and handled correctly — they should just be silent.

## Changes

- `src/config/GlobalConfig.ts`: change `:` to `=` on `defaultLogLevel`
- `src/config/GlobalConfig.test.ts`: new test file covering the default value and the `checkLogLevel` fallback behaviour

## Test plan

- [ ] `./node_modules/.bin/jest src/config/GlobalConfig.test.ts` — 4 tests pass
- [ ] Full suite passes (pre-existing failures in `FullTimeMatcher.test.ts` are unrelated to this change)
- [ ] After deploying, browser console no longer floods with `WR WARN Value from <entity> ignored: Object` on cards using the default log level

🤖 Generated with [Claude Code](https://claude.com/claude-code)