### PR TITLE
Fix console.info message typo in WindRoseCard.ts

### DIFF
--- a/src/card/WindRoseCard.ts
+++ b/src/card/WindRoseCard.ts
@@ -30,7 +30,7 @@ import {MeasurementHolder} from "../measurement-provider/MeasurementHolder";
 
 /* eslint no-console: 0 */
 console.info(
-    `%c  WINROSE-CARD  %c Version 2.4.0 `,
+    `%c  WINDROSE-CARD  %c Version 2.4.0 `,
     'color: orange; font-weight: bold; background: black',
     'color: white; font-weight: bold; background: dimgray',
 );


### PR DESCRIPTION
This pull request corrects a minor typo in the console output message for the WindRoseCard component. The word "WINROSE-CARD" was updated to the correct "WINDROSE-CARD" for consistency and clarity.