### PR TITLE
Fix support for older Android WebViews

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "http-server": "http-server ./",
     "lint": "npx eslint .",
     "typecheck": "tsc --noEmit",
-    "esbuild": "esbuild src/card/WindRoseCard.ts --bundle --minify --outfile=build/windrose-card.js",
-    "esbuild-watch": "esbuild src/card/WindRoseCard.ts --bundle --minify --outfile=build/windrose-card.js --watch",
+    "esbuild": "esbuild src/card/WindRoseCard.ts --bundle --minify --target=es2017 --outfile=build/windrose-card.js",
+    "esbuild-watch": "esbuild src/card/WindRoseCard.ts --bundle --minify --target=es2017 --outfile=build/windrose-card.js --watch",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- target the production bundle at ES2017
- keep the watch build aligned with the production build
- avoid ES2022 class static blocks that older Android WebViews cannot parse

## Testing

- built the card with the updated esbuild command
- installed the generated bundle on the affected Home Assistant wall-panel tablet
- verified that the windrose card renders again

Closes #221